### PR TITLE
Optionally show label on index view

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -202,9 +202,10 @@ class Button extends Field
         return $this;
     }
 
-    public function label($label)
+    public function label($label, $showOnIndex = false)
     {
         $this->label = $label;
+        if (!!$showOnIndex) $this->indexName = $label;
 
         return $this;
     }


### PR DESCRIPTION
Currently i don't seem to find a way to define a `indexName` that would be shown on resource index view header. 
Using `withMeta(['indexName' => '...'])` also doesn't work at the moment, because you are setting it to null in resolve function. 

This would allow the user to optionally pass in `true` as second argument to `label()` function. 
This would assign `$this->label` value to `$this->indexName` and allow us to show the label also on index view. 
